### PR TITLE
AlarmHandle example compile error

### DIFF
--- a/examples/AlarmHandler/AlarmHandler.pde
+++ b/examples/AlarmHandler/AlarmHandler.pde
@@ -44,7 +44,7 @@ void printAddress(DeviceAddress deviceAddress)
 void printTemp(DeviceAddress deviceAddress)
 {
   float tempC = sensors.getTempC(deviceAddress);
-  if (tempC != DEVICE_DISCONNECTED)
+  if (tempC != DEVICE_DISCONNECTED_C)
   {
     Serial.print("Current Temp C: ");
     Serial.print(tempC);


### PR DESCRIPTION
DEVICE_DISCONNECTED define no longer exists, changed to DEVICE_DISCONNECTED_C
